### PR TITLE
If email was not found, return an ENOTFOUND code to api_sails

### DIFF
--- a/handlers/user-password-reset-request.js
+++ b/handlers/user-password-reset-request.js
@@ -70,7 +70,7 @@ module.exports = {
                // Q: is there any additional management in this case?
                // eg: do we mark how many failed attempts and then block that browser?
                req.log("User not found: ", JSON.stringify(cond));
-               cb(null, { status: "success" });
+               cb(null, { status: "success", code: "ENOTFOUND" });
                return;
             }
             const user = list[0];


### PR DESCRIPTION
When a user wants to reset their password, they must enter their email address. Currently, if the email address cannot be found, AppBuilder will not complain. This helps to prevent hackers from using this method to find user emails.

But now there is an auth log file. And it needs to know if an invalid email was given for password reset. So here in `ab_service_user_manager`, we return an `ENOTFOUND` code back to `ab_service_api_sails`. It will delete the code before sending the result to the user.

See https://github.com/digi-serve/ab_service_api_sails/pull/49/files#diff-6a8f60b0cbfafd572115dc184e9af1a090c141c6847a91a9f4d9f1dcd30787b0
